### PR TITLE
Added MKV to list of supported video URL's for the HTML5 player

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Vynchronize is a real-time online video synchronization platform. You can enjoy any video available online with friends who may not be next to you!
 
-Vynchronize currently supports YouTube, Daily Motion, Vimeo, and essentially any .mp4/.webm on the internet with the HTML5 Player!
+Vynchronize currently supports YouTube, Daily Motion, Vimeo, and essentially any .mp4/.webm on the internet with the HTML5 Player! In fact, when using Google Chrome, you can also play H.264-encoded .mkv's (experimental)!
 
 [![forthebadge](https://forthebadge.com/images/badges/60-percent-of-the-time-works-every-time.svg)](http://forthebadge.com)
 

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                             <a class="dropdown-item" onclick="changePlayer(roomnum, 0)"><i class="fab fa-youtube"></i> YouTube</a>
                             <a class="dropdown-item" onclick="changePlayer(roomnum, 1)"><img width="14px" height="14px" src="img/dailymotion-logo.svg" alt="Daily Motion Logo"> Daily Motion</a>
                             <a class="dropdown-item" onclick="changePlayer(roomnum, 2)"><i class="fab fa-vimeo"></i> Vimeo</a>
-                            <a class="dropdown-item" onclick="changePlayer(roomnum, 3)"><i class="fas fa-file-video"></i> HTML5 Player (.mp4/.webm) (Beta)</a>
+                            <a class="dropdown-item" onclick="changePlayer(roomnum, 3)"><i class="fas fa-file-video"></i> HTML5 Player (.mp4/.webm/.mkv) (Beta)</a>
                         </div>
                     </div>
 

--- a/js/player.js
+++ b/js/player.js
@@ -225,7 +225,7 @@ socket.on('createHTML5', function(data) {
         document.getElementById('nextButton').style.display = 'none'
         document.getElementById('loveButton').style.display = 'none'
         // document.getElementById('html5-input').style.display = 'block'
-        document.getElementById('inputVideoId').placeholder = 'Direct mp4/webm URL'
+        document.getElementById('inputVideoId').placeholder = 'Direct mp4/webm/mkv URL'
         // document.getElementById('html5-message').style.display = 'block'
 
         betaAlert()


### PR DESCRIPTION
Added MKV to list of supported video URL's for the HTML5 player (Google Chrome only, experimental). Only MKV files using the H.264 codec are supported.